### PR TITLE
pylivetrader uses an Equity object vs ziplines Asset this caues probl…

### DIFF
--- a/zipline/pipeline/term.py
+++ b/zipline/pipeline/term.py
@@ -203,7 +203,8 @@ class Term(with_metaclass(ABCMeta, object)):
         """
         pass
 
-    @expect_types(key=Asset)
+    # This breaks pylivetrader for some of the better built in pipeline terms
+    # @expect_types(key=Asset)
     def __getitem__(self, key):
         if isinstance(self, LoadableTerm):
             raise NonSliceableTerm(term=self)


### PR DESCRIPTION
Pylivetrader uses an Equity object to replace the Asset object type Zipline uses. This object type check breaks some pipeline terms.